### PR TITLE
[CARBONDATA-4349] upgrade thrift version

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/reader/ThriftReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/ThriftReader.java
@@ -31,6 +31,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TIOStreamTransport;
+import org.apache.thrift.transport.TTransportException;
 
 /**
  * A simple class for reading Thrift objects (of a single type) from a fileName.
@@ -89,7 +90,11 @@ public class ThriftReader {
    */
   public ThriftReader(byte[] fileData) {
     dataInputStream = new DataInputStream(new ByteArrayInputStream(fileData));
-    binaryIn = new TCompactProtocol(new TIOStreamTransport(dataInputStream));
+    try {
+      binaryIn = new TCompactProtocol(new TIOStreamTransport(dataInputStream));
+    } catch (TTransportException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**
@@ -98,7 +103,11 @@ public class ThriftReader {
   public void open() throws IOException {
     Configuration conf = configuration != null ? configuration : FileFactory.getConfiguration();
     dataInputStream = FileFactory.getDataInputStream(fileName, conf);
-    binaryIn = new TCompactProtocol(new TIOStreamTransport(dataInputStream));
+    try {
+      binaryIn = new TCompactProtocol(new TIOStreamTransport(dataInputStream));
+    } catch (TTransportException e) {
+      throw new IOException(e);
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1413,8 +1413,8 @@ public final class CarbonUtil {
   public static byte[] getByteArray(TBase t) {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     byte[] thriftByteArray = null;
-    TProtocol binaryOut = new TCompactProtocol(new TIOStreamTransport(stream));
     try {
+      TProtocol binaryOut = new TCompactProtocol(new TIOStreamTransport(stream));
       t.write(binaryOut);
       stream.flush();
       thriftByteArray = stream.toByteArray();
@@ -1439,9 +1439,9 @@ public final class CarbonUtil {
 
   public static DataChunk3 readDataChunk3(InputStream stream) throws IOException {
     TBaseCreator creator = DataChunk3::new;
-    TProtocol binaryIn = new TCompactProtocol(new TIOStreamTransport(stream));
     TBase t = creator.create();
     try {
+      TProtocol binaryIn = new TCompactProtocol(new TIOStreamTransport(stream));
       t.read(binaryIn);
     } catch (TException e) {
       throw new IOException(e);
@@ -1461,9 +1461,9 @@ public final class CarbonUtil {
   private static TBase read(byte[] data, TBaseCreator creator, int offset, int length)
       throws IOException {
     ByteArrayInputStream stream = new ByteArrayInputStream(data, offset, length);
-    TProtocol binaryIn = new TCompactProtocol(new TIOStreamTransport(stream));
     TBase t = creator.create();
     try {
+      TProtocol binaryIn = new TCompactProtocol(new TIOStreamTransport(stream));
       t.read(binaryIn);
     } catch (TException e) {
       throw new IOException(e);

--- a/core/src/main/java/org/apache/carbondata/core/writer/ThriftWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/ThriftWriter.java
@@ -31,6 +31,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TIOStreamTransport;
+import org.apache.thrift.transport.TTransportException;
 
 /**
  * Simple class that makes it easy to write Thrift objects to disk.
@@ -80,7 +81,11 @@ public class ThriftWriter {
    */
   public void open() throws IOException {
     dataOutputStream = FileFactory.getDataOutputStream(fileName, bufferSize, append);
-    binaryOut = new TCompactProtocol(new TIOStreamTransport(dataOutputStream));
+    try {
+      binaryOut = new TCompactProtocol(new TIOStreamTransport(dataOutputStream));
+    } catch (TTransportException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -92,7 +97,11 @@ public class ThriftWriter {
   public void open(FileWriteOperation fileWriteOperation) throws IOException {
     atomicFileOperationsWriter = AtomicFileOperationFactory.getAtomicFileOperations(fileName);
     dataOutputStream = atomicFileOperationsWriter.openForWrite(fileWriteOperation);
-    binaryOut = new TCompactProtocol(new TIOStreamTransport(dataOutputStream));
+    try {
+      binaryOut = new TCompactProtocol(new TIOStreamTransport(dataOutputStream));
+    } catch (TTransportException e) {
+      throw new IOException(e);
+    }
   }
 
   /**

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -37,7 +37,12 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <version>0.9.3</version>
+      <version>0.17.0</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
   <properties>
     <!--    default properties-->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
     <snappy.version>1.1.2.6</snappy.version>
     <hadoop.version>2.7.2</hadoop.version>
     <httpclient.version>4.3.4</httpclient.version>


### PR DESCRIPTION
 ### Why is this PR needed?
 Thrift version 0.9.3 is not supported by new version of Linux
 
 ### What changes were proposed in this PR?
Thrift library version is upgraded from 0.9.3 to 0.17.0
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

Only thrift version is changed and compilation is fixed due to version upgrade.

    
